### PR TITLE
Revert Changes to Intern, Mentor, Sponsor headers at 320px

### DIFF
--- a/css/newDashboard.css
+++ b/css/newDashboard.css
@@ -56,7 +56,7 @@ a{
   .intern-buttons,
   .mentor-buttons{
 	display: flex;
-	margin: 5rem 0 1rem 0rem;
+	margin: 5.7rem 0 1rem 0rem;
   }
   .intern-buttons>.btn:nth-child(1),
   .mentor-buttons>.btn:nth-child(1){
@@ -480,12 +480,22 @@ i:hover{
 		font-size: 20px;
 		margin-top: 34px;
 	}
+	.mentor-table .btn:not(:last-child){
+		margin-bottom: 0.5em;
+		
+	}
+	.mentor-table .btn{
+		width: 77px;
+	}	
 }
 @media (max-width: 860px)
 {
+	#overview-section h2.register{
+		padding-left: 0.6em;
+		
+	}
 	#centralize{
 		height: 100%;
-		
 	}
 	main
 	{
@@ -729,6 +739,24 @@ i:hover{
 	.certificate-table .btn-sm{
 		margin-top: 0.25em;
 	}
+	.mentor-table .btn:not(:last-child),
+	.intern-table .btn:not(:last-child){
+		margin-bottom: 0.5em;
+	}
+	.mentor-table .btn{
+		width: 77px;
+	}
+	#my-table>thead>tr>th:nth-child(12),
+	.mentor-table td:nth-child(12){
+		text-align: center;
+	}
+	.mentor-table .btn.btn-danger.btn-sm{
+		margin-right: 5px;
+	}
+	/* .intern-table th:nth-child(12),
+	.intern-table td:nth-child(12){
+		text-align: center;
+	} */
 }
 
 @media (max-width: 375px){
@@ -753,11 +781,20 @@ i:hover{
 		margin-left: 1.5em;
 		margin-top: 18px;
 	}
+	
 }
 
 @media (max-width: 359px){
 	
   	.mentor-buttons.certificate>.btn:nth-child(1){
 		margin-right: 0;
+	}
+	.intern-buttons .btn:not(:last-child),
+	.mentor-buttons .btn:not(:last-child){
+		margin-left: 0;
+	}
+	#overview-section .row h2{
+		padding-left: 4px;
+		padding-right: 4px;
 	}
 }

--- a/dashboard.php
+++ b/dashboard.php
@@ -343,11 +343,11 @@ if($display["hasPic"] == 0) {
               
                 <div class="options">
                   <label for="internLocation">
-                    <input type="radio" name="byLocation" id="internLocation" value="internLocation" checked /> Interns
+                    <input type="radio" name="byLocation" id="internLocation" value="internLocation"  /> Interns
                   </label>
             
                   <label for="mentorLocation">
-                   <input type="radio" name="byLocation" id="mentorLocation" value="mentorLocation" /> Mentors
+                   <input type="radio" name="byLocation" id="mentorLocation" value="mentorLocation" checked/> Mentors
                   </label>
                </div>
               </div>
@@ -366,11 +366,11 @@ if($display["hasPic"] == 0) {
               
               <div class="options">
                 <label for="internTrack">
-                  <input type="radio" name="byTrack" id="internTrack" value="internTrack" checked/> Interns
+                  <input type="radio" name="byTrack" id="internTrack" value="internTrack" /> Interns
                 </label>
               
                 <label for="mentorTrack">
-                  <input type="radio" name="byTrack" id="mentorTrack" value="mentorTrack" /> Mentors
+                  <input type="radio" name="byTrack" id="mentorTrack" value="mentorTrack" checked/> Mentors
                 </label>
                </div>
               </div>

--- a/declined_interns.php
+++ b/declined_interns.php
@@ -48,7 +48,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
     <style type="text/css">
-        .card {
+        /* .card {
             height: 150px;
             background: #ccc;
             margin: 15px;
@@ -72,7 +72,7 @@
      .fa-search{
       margin-top: 10px;
      }
-    }
+    } */
     </style>
 
 </head>

--- a/declined_mentors.php
+++ b/declined_mentors.php
@@ -41,7 +41,7 @@ if (isset($_GET['rejectMentorId'])) {
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
     <style type="text/css">
-        .card {
+        /* .card {
             height: 150px;
             background: #ccc;
             margin: 15px;
@@ -65,7 +65,7 @@ if (isset($_GET['rejectMentorId'])) {
      .fa-search{
       margin-top: 10px;
      }
-    }
+    } */
     </style>
 
 </head>
@@ -119,7 +119,7 @@ if (isset($_GET['rejectMentorId'])) {
                         <div id="printablediv">
                             <div class="scroll">
                             <!-- <table id="my-table" class="table table-hover table-bordered mt-3 mb-1"> -->
-                            <table id="my-table" class="table table-hover mentor-table">
+                            <table id="my-table" class="table table-hover mentor-table declined">
                                 <!-- <thead class="table-primary"> -->
                                 <thead>
                                     <tr>

--- a/finished_request.php
+++ b/finished_request.php
@@ -39,7 +39,7 @@ if ($status) {
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
   <style type="text/css">
-    .card {
+    /* .card {
       height: 150px;
       background: #ccc;
       margin: 15px;
@@ -63,7 +63,7 @@ if ($status) {
      .fa-search{
       margin-top: 10px;
      }
-    }
+    } */
   </style>
 
 </head>

--- a/fragments/sidebar.php
+++ b/fragments/sidebar.php
@@ -40,7 +40,7 @@
 				<a href="internreview"><i class="fas fa-history"></i>Reviews</a>
 				<a href="updateCountdown"><i class="far fa-clock"></i>CountDown</a>
 				<a href="pending_request"><i class="fas fa-certificate"></i>Certificate</a>
-                <a href="incoming_donations"><i class="fas fa-check"></i>Incoming Donation</a>
+                <a href="incoming_donations"><i class="fas fa-donate"></i>Donations</a>
 			</div>
 		</li>
 		<li class="item" id="news">

--- a/pending_interns.php
+++ b/pending_interns.php
@@ -48,7 +48,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
     <style type="text/css">
-        .card {
+        /* .card {
             height: 150px;
             background: #ccc;
             margin: 15px;
@@ -72,7 +72,7 @@
      .fa-search{
       margin-top: 10px;
      }
-    }
+    } */
     </style>
 
 </head>

--- a/pending_mentors.php
+++ b/pending_mentors.php
@@ -44,7 +44,7 @@ if (isset($_GET['rejectMentorId'])) {
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
     <style type="text/css">
-        .card {
+        /* .card {
             height: 150px;
             background: #ccc;
             margin: 15px;
@@ -68,7 +68,7 @@ if (isset($_GET['rejectMentorId'])) {
      .fa-search{
       margin-top: 10px;
      }
-    }
+    } */
     </style>
 
 </head>

--- a/pending_request.php
+++ b/pending_request.php
@@ -39,7 +39,7 @@ if ($status) {
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
   <style type="text/css">
-    .card {
+    /* .card {
       height: 150px;
       background: #ccc;
       margin: 15px;
@@ -63,7 +63,7 @@ if ($status) {
      .fa-search{
       margin-top: 10px;
      }
-    }
+    } */
 
   </style>
 

--- a/processing_request.php
+++ b/processing_request.php
@@ -39,7 +39,7 @@ if ($status) {
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
   <style type="text/css">
-    .card {
+    /* .card {
       height: 150px;
       background: #ccc;
       margin: 15px;
@@ -62,7 +62,7 @@ if ($status) {
 
      .fa-search{
       margin-top: 10px;
-     }
+     } */
     }
   </style>
 

--- a/registered_interns.php
+++ b/registered_interns.php
@@ -48,7 +48,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
     <style type="text/css">
-        .card {
+        /* .card {
             height: 150px;
             background: #ccc;
             margin: 15px;
@@ -72,7 +72,7 @@
      .fa-search{
       margin-top: 10px;
      }
-    }
+    } */
     </style>
 
 </head>

--- a/registered_mentors.php
+++ b/registered_mentors.php
@@ -41,7 +41,7 @@ if (isset($_GET['rejectMentorId'])) {
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
     <style type="text/css">
-        .card {
+        /* .card {
             height: 150px;
             background: #ccc;
             margin: 15px;
@@ -65,7 +65,7 @@ if (isset($_GET['rejectMentorId'])) {
      .fa-search{
       margin-top: 10px;
      }
-    }
+    } */
     </style>
 
 </head>
@@ -119,7 +119,7 @@ if (isset($_GET['rejectMentorId'])) {
                         <div id="printablediv">
                             <div class="scroll">
                             <!-- <table id="my-table" class="table table-hover table-bordered mt-3 mb-1"> -->
-                            <table id="my-table" class="table table-hover mentor-table">
+                            <table id="my-table" class="table table-hover mentor-table registered">
                                 <!-- <thead class="table-primary"> -->
                                 <thead>
                                     <tr>

--- a/registered_sponsors.php
+++ b/registered_sponsors.php
@@ -33,7 +33,7 @@ $data = $sponsors->getAllSponsor();
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 
     <style type="text/css">
-        .card {
+        /* .card {
             height: 150px;
             background: #ccc;
             margin: 15px;
@@ -57,7 +57,7 @@ $data = $sponsors->getAllSponsor();
      .fa-search{
       margin-top: 10px;
      }
-    }
+    } */
     </style>
 
 </head>


### PR DESCRIPTION
![declined interns](https://user-images.githubusercontent.com/45360667/68546572-0894a500-03d8-11ea-84e8-afd5bf77e966.PNG)
![reg sposors](https://user-images.githubusercontent.com/45360667/68546575-0f231c80-03d8-11ea-88f3-4ea8ea062f7f.PNG)
Someone wrote internal style sheets on the various Sponsor , Mentor and Intern pages which forced the headers to wrap at 320px (as seen above). Also, "There are no declined or Pending Intern/Mentor " messages now appear truncated. This fix is to revert the changes made to these pages.
Test here: https://hngi.herokuapp.com